### PR TITLE
Add Nix flake definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v19
-    - name: Build pdf
-      run: nix develop -c ./build.sh 2023
-    - name: Output pdf
+    - name: Build PDFs
+      run: nix build
+    - name: Copy PDFs
+      run: cp result/*.pdf .
+    - name: Output PDFs
       uses: actions/upload-artifact@v3
       with:
-        name: output
-        path: planner.2023.pdf
+        name: result
+        path: ./*.pdf
+        if-no-files-found: error
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: "Build 2023"
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+    - name: Build pdf
+      run: nix develop -c ./build.sh 2023
+    - name: Output pdf
+      uses: actions/upload-artifact@v3
+      with:
+        name: output
+        path: planner.2023.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pdf
 .vscode
+result

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ If you encounter any problems related to '.sty' files you likely need to
 Instead of installing the dependencies manually, this repository is defined as a Nix flake which specifies fixed versions of all the required dependencies. 
 
 1. [Install Nix](https://nixos.org/download.html)
-2. Build a planner pdf using `nix develop -c ./build.sh 2023"
+2. Build a planner pdf using `nix build`
+3. Or, if you want to develop the code, enter a shell with all the dependencies present using `nix develop`
    
 # Preview examples
 <img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/01_annual.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/02_quarter.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/03_month.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/04_week.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/05_day.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/06_day_notes.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/07_day_reflect.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/08_todos_index.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/09_todos_page.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/10_notes_index.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/11_notes_page.png" width="419">

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ If you encounter any problems related to '.sty' files you likely need to
  install some Latex related dependencies. Copying the error and search using
   your favorite search engine should get you on track to resolving the
    dependency issues. All the best!
+
+### Alternative install
+
+Instead of installing the dependencies manually, this repository is defined as a Nix flake which specifies fixed versions of all the required dependencies. 
+
+1. [Install Nix](https://nixos.org/download.html)
+2. Build a planner pdf using `nix develop -c ./build.sh 2023"
    
 # Preview examples
 <img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/01_annual.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/02_quarter.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/03_month.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/04_week.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/05_day.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/06_day_notes.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/07_day_reflect.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/08_todos_index.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/09_todos_page.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/10_notes_index.png" width="419"><img src="https://github.com/kudrykv/latex-yearly-planner/blob/main/examples/pictures/sn_a5x.planner/11_notes_page.png" width="419">

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677622273,
+        "narHash": "sha256-LUqCVhzxr7EVY+SzW1uTXaMoVRUR2OP4Fr/tmJV7lHE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "995edc972ad3a1e291ac22d74b9610821357175f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,28 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        # Build the plannergen as a binary using fixed input versions
+        # This means that the subsequent pdf generation does not need internet access
+        # and is therefore a "pure" nix output
+        plannergen = pkgs.buildGoModule {
+          src = self;
+          name = "plannergen";
+          vendorSha256 = "sha256:F3cln/CPSAonLTCvjSCMHhrzEQgWIOWw0vWwb6BG+pI=";
+        };
+
+        # Go is packaged into the devShell for developing the package, 
+        # but is not used for the "nix build" outputs - these use the pre-built
+        # binary instead
         goDeps = [
           pkgs.go
         ];
+
+        # Dependencies for building the latex files
         texDeps = with pkgs; [
+          libuuid # for the "rev" utility
+          ps # Used by build.sh
+          python3 # used in the build scripts
           (texlive.combine {
             inherit (texlive)
               metafont
@@ -34,6 +52,7 @@
           })
         ];
       in
+      rec
       {
         devShell = pkgs.mkShell {
           shellHook = ''
@@ -42,9 +61,31 @@
             unset GO_VERSION
           '';
           buildInputs = [
-            pkgs.nixpkgs-fmt
+            pkgs.nixpkgs-fmt # utility for pretty formatting of .nix files
           ] ++ goDeps ++ texDeps;
         };
+
+        defaultPackage = pdfs;
+
+        pdfs = pkgs.stdenv.mkDerivation
+          {
+            name = "pdfs";
+            # Minimal set of dependencies to build the pdfs
+            # Latex, "rev" and the built plannergen binary
+            buildInputs = texDeps ++ [ plannergen ];
+            PLANNER_YEAR = 2023;
+            src = "${self}";
+            buildCommand = ''
+              cp -r $src/* .
+              patchShebangs .
+              chmod -R 770 *
+              chmod +x *.sh
+              PLANNERGEN_BINARY=plannergen eval $PWD/build.sh
+              mkdir $out
+              cp *.pdf $out/.
+            '';
+          };
+
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Install latex reqs";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        goDeps = [
+          pkgs.go
+        ];
+        texDeps = with pkgs; [
+          (texlive.combine {
+            inherit (texlive)
+              metafont
+              scheme-basic
+              xcolor
+              pgf
+              wrapfig
+              makecell
+              multirow
+              leading
+              marginnote
+              adjustbox
+              multido
+              varwidth
+              blindtext
+              setspace
+              ifmtarg
+              extsizes
+              dashrule
+              ;
+          })
+        ];
+      in
+      {
+        devShell = pkgs.mkShell {
+          shellHook = ''
+            unset GOPATH
+            unset GOROOT
+            unset GO_VERSION
+          '';
+          buildInputs = [
+            pkgs.nixpkgs-fmt
+          ] ++ goDeps ++ texDeps;
+        };
+      }
+    );
+}

--- a/single.sh
+++ b/single.sh
@@ -2,10 +2,17 @@
 
 set -eo pipefail
 
-if [ -z "$PREVIEW" ]; then
-  go run cmd/plannergen/plannergen.go --config "${CFG}"
+if [ -z "$PLANNERGEN_BINARY" ]; then
+  export GO_CMD="go run cmd/plannergen/plannergen.go"
 else
-  go run cmd/plannergen/plannergen.go --preview --config "${CFG}"
+  export GO_CMD="$PLANNERGEN_BINARY"
+  echo "Building using plannergen binary at \"${PLANNERGEN_BINARY}\""
+fi
+
+if [ -z "$PREVIEW" ]; then
+  eval $GO_CMD --config "${CFG}"
+else
+  eval $GO_CMD --preview --config "${CFG}"
 fi
 
 


### PR DESCRIPTION
Thanks for an awesome package! The dependency setup was a bit fiddly and might put people off developing, so I've added a Nix flake which allows you to create a temporary environment with all dependencies pre-packaged. Building the package now becomes just a call to 

```
nix develop -c ./build.sh
```

I've also added a github workflow which build this automatically in the Github CI. It's currently always building the 2023 file, but that could be changed easily enough if you prefer. 